### PR TITLE
feat: normalize customer profile schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ docker-compose.override.yml
 # OS-specific files
 .DS_Store
 Thumbs.db
+**/node_modules/
+**/coverage/
+**/package-lock.json

--- a/db/.env.example
+++ b/db/.env.example
@@ -1,0 +1,11 @@
+# App: Client Profile Module
+# Package: db
+# File: .env.example
+# Version: 0.0.1
+# Author: Bobwares
+# Date: 2025-06-10T00:00:00Z
+# Description: Example environment variables for local database.
+
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_DB=customer_db

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,16 @@
+# App: Client Profile Module
+# Package: db
+# File: Dockerfile
+# Version: 0.0.1
+# Author: Bobwares
+# Date: 2025-06-10T00:00:00Z
+# Description: Build PostgreSQL 16 image with initialization scripts.
+
+FROM postgres:16-alpine
+
+ENV POSTGRES_USER=${POSTGRES_USER} \
+    POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
+    POSTGRES_DB=${POSTGRES_DB}
+
+COPY migrations/ /docker-entrypoint-initdb.d/migrations/
+COPY scripts/ /docker-entrypoint-initdb.d/scripts/

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -1,0 +1,25 @@
+# App: Client Profile Module
+# Package: db
+# File: docker-compose.yml
+# Version: 0.0.1
+# Author: Bobwares
+# Date: 2025-06-10T00:00:00Z
+# Description: Compose file for PostgreSQL service.
+
+version: "3.9"
+services:
+  db:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+volumes:
+  db-data:

--- a/db/migrations/20250610120000_create_customer_profile.sql
+++ b/db/migrations/20250610120000_create_customer_profile.sql
@@ -1,0 +1,18 @@
+-- App: Client Profile Module
+-- Package: db
+-- File: 20250610120000_create_customer_profile.sql
+-- Version: 0.0.1
+-- Author: Bobwares
+-- Date: 2025-06-10T00:00:00Z
+-- Description: Initial table for customer profiles.
+
+CREATE TABLE IF NOT EXISTS customer_profile (
+    id UUID PRIMARY KEY,
+    first_name TEXT NOT NULL,
+    middle_name TEXT,
+    last_name TEXT NOT NULL,
+    emails TEXT[] NOT NULL,
+    phone_numbers JSONB NOT NULL,
+    address JSONB,
+    privacy_settings JSONB NOT NULL
+);

--- a/db/migrations/20250611120000_refactor_customer_profile.sql
+++ b/db/migrations/20250611120000_refactor_customer_profile.sql
@@ -1,0 +1,47 @@
+-- App: Client Profile Module
+-- Package: db
+-- File: 20250611120000_refactor_customer_profile.sql
+-- Version: 0.0.2
+-- Author: Bobwares
+-- Date: 2025-06-09T20:32:51Z
+-- Description: Normalize customer profile into relational tables.
+
+DROP TABLE IF EXISTS customer_profile CASCADE;
+
+CREATE TABLE IF NOT EXISTS customer_profile (
+    id UUID PRIMARY KEY,
+    first_name TEXT NOT NULL,
+    middle_name TEXT,
+    last_name TEXT NOT NULL,
+    marketing_emails_enabled BOOLEAN NOT NULL,
+    two_factor_enabled BOOLEAN NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS customer_email (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL REFERENCES customer_profile(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    UNIQUE (customer_id, email)
+);
+
+CREATE TABLE IF NOT EXISTS customer_phone_number (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL REFERENCES customer_profile(id) ON DELETE CASCADE,
+    type TEXT NOT NULL CHECK (type IN ('mobile','home','work','other')),
+    number TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS customer_address (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL UNIQUE REFERENCES customer_profile(id) ON DELETE CASCADE,
+    line1 TEXT NOT NULL,
+    line2 TEXT,
+    city TEXT NOT NULL,
+    state TEXT NOT NULL,
+    postal_code TEXT NOT NULL,
+    country CHAR(2) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_profile_last_name ON customer_profile (last_name);
+CREATE INDEX IF NOT EXISTS idx_customer_email_email ON customer_email (email);
+CREATE INDEX IF NOT EXISTS idx_phone_number_customer ON customer_phone_number (customer_id);

--- a/db/scripts/schema/01_create_extensions.sql
+++ b/db/scripts/schema/01_create_extensions.sql
@@ -1,0 +1,9 @@
+-- App: Client Profile Module
+-- Package: db
+-- File: 01_create_extensions.sql
+-- Version: 0.0.1
+-- Author: Bobwares
+-- Date: 2025-06-10T00:00:00Z
+-- Description: Create required database extensions.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/db/scripts/schema/02_create_tables.sql
+++ b/db/scripts/schema/02_create_tables.sql
@@ -1,0 +1,41 @@
+-- App: Client Profile Module
+-- Package: db
+-- File: 02_create_tables.sql
+-- Version: 0.0.2
+-- Author: Bobwares
+-- Date: 2025-06-09T20:32:51Z
+-- Description: Create tables for customer profiles using relational model.
+
+CREATE TABLE IF NOT EXISTS customer_profile (
+    id UUID PRIMARY KEY,
+    first_name TEXT NOT NULL,
+    middle_name TEXT,
+    last_name TEXT NOT NULL,
+    marketing_emails_enabled BOOLEAN NOT NULL,
+    two_factor_enabled BOOLEAN NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS customer_email (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL REFERENCES customer_profile(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    UNIQUE (customer_id, email)
+);
+
+CREATE TABLE IF NOT EXISTS customer_phone_number (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL REFERENCES customer_profile(id) ON DELETE CASCADE,
+    type TEXT NOT NULL CHECK (type IN ('mobile','home','work','other')),
+    number TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS customer_address (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL UNIQUE REFERENCES customer_profile(id) ON DELETE CASCADE,
+    line1 TEXT NOT NULL,
+    line2 TEXT,
+    city TEXT NOT NULL,
+    state TEXT NOT NULL,
+    postal_code TEXT NOT NULL,
+    country CHAR(2) NOT NULL
+);

--- a/db/scripts/schema/03_create_indexes.sql
+++ b/db/scripts/schema/03_create_indexes.sql
@@ -1,0 +1,11 @@
+-- App: Client Profile Module
+-- Package: db
+-- File: 03_create_indexes.sql
+-- Version: 0.0.2
+-- Author: Bobwares
+-- Date: 2025-06-09T20:32:51Z
+-- Description: Create indexes for customer profile tables.
+
+CREATE INDEX IF NOT EXISTS idx_customer_profile_last_name ON customer_profile (last_name);
+CREATE INDEX IF NOT EXISTS idx_customer_email_email ON customer_email (email);
+CREATE INDEX IF NOT EXISTS idx_phone_number_customer ON customer_phone_number (customer_id);

--- a/db/scripts/seed/01_seed_sample_customers.sql
+++ b/db/scripts/seed/01_seed_sample_customers.sql
@@ -1,0 +1,31 @@
+-- App: Client Profile Module
+-- Package: db
+-- File: 01_seed_sample_customers.sql
+-- Version: 0.0.2
+-- Author: Bobwares
+-- Date: 2025-06-09T20:32:51Z
+-- Description: Insert a sample customer profile using relational tables.
+
+DO $$
+DECLARE
+    cid UUID := gen_random_uuid();
+BEGIN
+    INSERT INTO customer_profile (
+        id, first_name, middle_name, last_name,
+        marketing_emails_enabled, two_factor_enabled
+    ) VALUES (
+        cid, 'Alice', NULL, 'Smith', TRUE, FALSE
+    );
+
+    INSERT INTO customer_email (customer_id, email)
+    VALUES (cid, 'alice@example.com');
+
+    INSERT INTO customer_phone_number (customer_id, type, number)
+    VALUES (cid, 'mobile', '+15555550123');
+
+    INSERT INTO customer_address (
+        customer_id, line1, city, state, postal_code, country
+    ) VALUES (
+        cid, '123 Main St', 'Metropolis', 'NY', '10001', 'US'
+    );
+END $$;

--- a/schema/customer_profile.json
+++ b/schema/customer_profile.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CustomerProfile",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the customer profile"
+    },
+    "fullName": {
+      "$ref": "#/definitions/FullName"
+    },
+    "emails": {
+      "type": "array",
+      "description": "List of the customer’s email addresses",
+      "items": {
+        "type": "string",
+        "format": "email"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "phoneNumbers": {
+      "type": "array",
+      "description": "List of the customer’s phone numbers",
+      "items": {
+        "$ref": "#/definitions/PhoneNumber"
+      },
+      "minItems": 1
+    },
+    "address": {
+      "$ref": "#/definitions/PostalAddress"
+    },
+    "privacySettings": {
+      "$ref": "#/definitions/PrivacySettings"
+    }
+  },
+  "required": [
+    "id",
+    "fullName",
+    "emails",
+    "privacySettings"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "FullName": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Customer’s given name"
+        },
+        "middleName": {
+          "type": "string",
+          "description": "Customer’s middle name or initial",
+          "minLength": 1
+        },
+        "lastName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Customer’s family name"
+        }
+      },
+      "required": ["firstName", "lastName"],
+      "additionalProperties": false
+    },
+    "PhoneNumber": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of phone number",
+          "enum": ["mobile", "home", "work", "other"]
+        },
+        "number": {
+          "type": "string",
+          "pattern": "^\\+?[1-9]\\d{1,14}$",
+          "description": "Phone number in E.164 format"
+        }
+      },
+      "required": ["type", "number"],
+      "additionalProperties": false
+    },
+    "PostalAddress": {
+      "type": "object",
+      "properties": {
+        "line1": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Street address, P.O. box, company name, c/o"
+        },
+        "line2": {
+          "type": "string",
+          "description": "Apartment, suite, unit, building, floor, etc."
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "description": "City or locality"
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1,
+          "description": "State, province, or region"
+        },
+        "postalCode": {
+          "type": "string",
+          "description": "ZIP or postal code"
+        },
+        "country": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 2,
+          "description": "ISO 3166-1 alpha-2 country code"
+        }
+      },
+      "required": ["line1", "city", "state", "postalCode", "country"],
+      "additionalProperties": false
+    },
+    "PrivacySettings": {
+      "type": "object",
+      "properties": {
+        "marketingEmailsEnabled": {
+          "type": "boolean",
+          "description": "Whether the user opts in to marketing emails"
+        },
+        "twoFactorEnabled": {
+          "type": "boolean",
+          "description": "Whether two-factor authentication is enabled"
+        }
+      },
+      "required": [
+        "marketingEmailsEnabled",
+        "twoFactorEnabled"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/version.md
+++ b/version.md
@@ -1,0 +1,2 @@
+0.0.1 - Setup PostgreSQL docker environment and added customer profile schema. 2025-06-09T20:22:33Z
+0.0.2 - Normalize customer profile into relational tables. 2025-06-09T20:32:51Z work


### PR DESCRIPTION
# Summary
Normalize customer profile database tables.

# Details
* **What was added/changed?**
  * Added a migration that replaces JSON fields with relational tables.
  * Updated base schema, indexes and seed data to match the new model.
  * Bumped version to 0.0.2.
* **Why was it needed?**
  * To store emails, phone numbers and addresses in separate tables.
* **How was it implemented?** (key design points)
  * New `customer_email`, `customer_phone_number` and `customer_address` tables with foreign keys.
  * Seed script uses a DO block to insert related rows atomically.

# Related Tickets
- None

# Checklist
- [ ] Unit tests pass (`npm test` / `pytest`)
- [ ] Integration tests pass
- [ ] Linter passes (`eslint` / `ruff`)
- [ ] Documentation updated (`README.md`, API docs)

# Screenshots / Demo (if UI)
- N/A

# Breaking Changes
- Dropped original `customer_profile` table definition.

------
https://chatgpt.com/codex/tasks/task_e_6847410131b0832d83a4fb2726f1599b