### PR TITLE
feat: add customer CRUD with postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ A basic REST API is exposed under `/api`:
 * **GET** `/profile/:id` – Retrieve a single profile
 * **PUT** `/profile/:id` – Update a profile
 * **DELETE** `/profile/:id` – Remove a profile
+* **GET** `/customers` – List customers
+* **POST** `/customers` – Create a customer
+* **GET** `/customers/:id` – Get a customer
+* **PUT** `/customers/:id` – Update a customer
+* **DELETE** `/customers/:id` – Delete a customer
 
 If Swagger is enabled, visit `http://localhost:3001/api` to explore the API documentation.
 

--- a/api/README.md
+++ b/api/README.md
@@ -124,3 +124,21 @@ project_root/api/
 ## License
 
 This project is licensed under the MIT License. See `LICENSE` for details.
+
+## Customers API
+
+The Customers API provides CRUD operations for customer records.
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/customers` | List all customers |
+| GET | `/customers/:id` | Retrieve a customer by ID |
+| POST | `/customers` | Create a new customer |
+| PUT | `/customers/:id` | Update an existing customer |
+| DELETE | `/customers/:id` | Remove a customer |
+
+### Database Setup
+
+1. `cd project_root/db && docker-compose up -d` to start PostgreSQL.
+2. `npm run typeorm:migration:run` to apply migrations.
+3. `npm run start:dev` to run the server.

--- a/api/e2e/customers.http
+++ b/api/e2e/customers.http
@@ -1,0 +1,12 @@
+### Create customer
+POST http://localhost:3001/customers
+Content-Type: application/json
+
+{
+  "fullName": {"firstName": "Alice", "lastName": "Smith"},
+  "emails": ["alice@example.com"],
+  "privacySettings": {"marketingEmailsEnabled": true, "twoFactorEnabled": false}
+}
+
+### List customers
+GET http://localhost:3001/customers

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,0 +1,26 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/app.module.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Root module configuring TypeORM and feature modules.
+// 
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { CustomerModule } from './customers/customer.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      autoLoadEntities: true,
+      synchronize: false,
+    }),
+    CustomerModule,
+  ],
+})
+export class AppModule {}

--- a/api/src/customers/customer.controller.test.ts
+++ b/api/src/customers/customer.controller.test.ts
@@ -1,0 +1,39 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/customer.controller.test.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Unit tests for CustomerController endpoints.
+// 
+import { Test } from '@nestjs/testing';
+import { CustomerController } from './customer.controller';
+import { CustomerService } from './customer.service';
+
+const serviceMock = () => ({
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+});
+
+describe('CustomerController', () => {
+  let controller: CustomerController;
+  let service: CustomerService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [CustomerController],
+      providers: [{ provide: CustomerService, useFactory: serviceMock }],
+    }).compile();
+
+    controller = module.get(CustomerController);
+    service = module.get(CustomerService);
+  });
+
+  it('calls service create', async () => {
+    await controller.create({} as any);
+    expect(service.create).toHaveBeenCalled();
+  });
+});

--- a/api/src/customers/customer.controller.ts
+++ b/api/src/customers/customer.controller.ts
@@ -1,0 +1,42 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/customer.controller.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Controller exposing REST endpoints for Customer operations.
+// 
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { CustomerService } from './customer.service';
+import { CreateCustomerDto } from './dtos/create-customer.dto';
+import { UpdateCustomerDto } from './dtos/update-customer.dto';
+
+@Controller('customers')
+export class CustomerController {
+  constructor(private readonly service: CustomerService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateCustomerDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateCustomerDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/api/src/customers/customer.entity.ts
+++ b/api/src/customers/customer.entity.ts
@@ -1,0 +1,40 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/customer.entity.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: TypeORM entity representing a customer record.
+// 
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+} from 'typeorm';
+
+@Entity({ name: 'customers' })
+export class Customer {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  firstName!: string;
+
+  @Column({ nullable: true })
+  middleName?: string;
+
+  @Column()
+  lastName!: string;
+
+  @Column('simple-array')
+  emails!: string[];
+
+  @Column('jsonb', { nullable: true })
+  phoneNumbers?: { type: string; number: string }[];
+
+  @Column('jsonb', { nullable: true })
+  address?: Record<string, unknown>;
+
+  @Column('jsonb')
+  privacySettings!: { marketingEmailsEnabled: boolean; twoFactorEnabled: boolean };
+}

--- a/api/src/customers/customer.module.ts
+++ b/api/src/customers/customer.module.ts
@@ -1,0 +1,20 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/customer.module.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Module encapsulating Customer controller, service and entity.
+// 
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Customer } from './customer.entity';
+import { CustomerService } from './customer.service';
+import { CustomerController } from './customer.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Customer])],
+  providers: [CustomerService],
+  controllers: [CustomerController],
+})
+export class CustomerModule {}

--- a/api/src/customers/customer.service.test.ts
+++ b/api/src/customers/customer.service.test.ts
@@ -1,0 +1,45 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/customer.service.test.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Unit tests for CustomerService CRUD methods.
+// 
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CustomerService } from './customer.service';
+import { Customer } from './customer.entity';
+
+const repoMock = () => ({
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  delete: jest.fn(),
+});
+
+describe('CustomerService', () => {
+  let service: CustomerService;
+  let repo: Repository<Customer>;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        CustomerService,
+        { provide: getRepositoryToken(Customer), useFactory: repoMock },
+      ],
+    }).compile();
+
+    service = module.get(CustomerService);
+    repo = module.get(getRepositoryToken(Customer));
+  });
+
+  it('creates a customer', async () => {
+    (repo.create as jest.Mock).mockReturnValue({});
+    (repo.save as jest.Mock).mockResolvedValue({ id: '1' });
+    const result = await service.create({} as any);
+    expect(result).toEqual({ id: '1' });
+  });
+});

--- a/api/src/customers/customer.service.ts
+++ b/api/src/customers/customer.service.ts
@@ -1,0 +1,47 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/customer.service.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Service providing CRUD operations for Customer entity.
+// 
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Customer } from './customer.entity';
+import { CreateCustomerDto } from './dtos/create-customer.dto';
+import { UpdateCustomerDto } from './dtos/update-customer.dto';
+
+@Injectable()
+export class CustomerService {
+  constructor(
+    @InjectRepository(Customer)
+    private readonly repo: Repository<Customer>,
+  ) {}
+
+  async create(dto: CreateCustomerDto): Promise<Customer> {
+    const entity = this.repo.create(dto as unknown as Customer);
+    return this.repo.save(entity);
+  }
+
+  findAll(): Promise<Customer[]> {
+    return this.repo.find();
+  }
+
+  findOne(id: string): Promise<Customer | null> {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  async update(id: string, dto: UpdateCustomerDto): Promise<Customer | null> {
+    const entity = await this.repo.findOne({ where: { id } });
+    if (!entity) return null;
+    Object.assign(entity, dto);
+    return this.repo.save(entity);
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const result = await this.repo.delete(id);
+    return result.affected ? result.affected > 0 : false;
+  }
+}

--- a/api/src/customers/dtos/create-customer.dto.test.ts
+++ b/api/src/customers/dtos/create-customer.dto.test.ts
@@ -1,0 +1,24 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/dtos/create-customer.dto.test.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Unit tests for CreateCustomerDto validation.
+// 
+import "reflect-metadata";
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateCustomerDto } from './create-customer.dto';
+
+describe('CreateCustomerDto', () => {
+  it('validates required fields', async () => {
+    const dto = plainToInstance(CreateCustomerDto, {
+      fullName: { firstName: 'Alice', lastName: 'Smith' },
+      emails: ['alice@example.com'],
+      privacySettings: { marketingEmailsEnabled: true, twoFactorEnabled: false },
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+});

--- a/api/src/customers/dtos/create-customer.dto.ts
+++ b/api/src/customers/dtos/create-customer.dto.ts
@@ -1,0 +1,83 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/dtos/create-customer.dto.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: DTO for creating a customer with validation rules.
+// 
+import { IsArray, IsBoolean, IsEmail, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class FullNameDto {
+  @IsString()
+  firstName!: string;
+
+  @IsOptional()
+  @IsString()
+  middleName?: string;
+
+  @IsString()
+  lastName!: string;
+}
+
+class PhoneNumberDto {
+  @IsString()
+  type!: string;
+
+  @IsString()
+  number!: string;
+}
+
+class AddressDto {
+  @IsString()
+  line1!: string;
+
+  @IsOptional()
+  @IsString()
+  line2?: string;
+
+  @IsString()
+  city!: string;
+
+  @IsString()
+  state!: string;
+
+  @IsString()
+  postalCode!: string;
+
+  @IsString()
+  country!: string;
+}
+
+class PrivacyDto {
+  @IsBoolean()
+  marketingEmailsEnabled!: boolean;
+
+  @IsBoolean()
+  twoFactorEnabled!: boolean;
+}
+
+export class CreateCustomerDto {
+  @ValidateNested()
+  @Type(() => FullNameDto)
+  fullName!: FullNameDto;
+
+  @IsArray()
+  @IsEmail({}, { each: true })
+  emails!: string[];
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => PhoneNumberDto)
+  phoneNumbers?: PhoneNumberDto[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AddressDto)
+  address?: AddressDto;
+
+  @ValidateNested()
+  @Type(() => PrivacyDto)
+  privacySettings!: PrivacyDto;
+}

--- a/api/src/customers/dtos/update-customer.dto.test.ts
+++ b/api/src/customers/dtos/update-customer.dto.test.ts
@@ -1,0 +1,20 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/dtos/update-customer.dto.test.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Unit tests for UpdateCustomerDto partial validation.
+// 
+import "reflect-metadata";
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateCustomerDto } from './update-customer.dto';
+
+describe('UpdateCustomerDto', () => {
+  it('allows partial fields', async () => {
+    const dto = plainToInstance(UpdateCustomerDto, { emails: ['bob@example.com'] });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+});

--- a/api/src/customers/dtos/update-customer.dto.ts
+++ b/api/src/customers/dtos/update-customer.dto.ts
@@ -1,0 +1,12 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/customers/dtos/update-customer.dto.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: DTO for updating a customer, all fields optional.
+// 
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCustomerDto } from './create-customer.dto';
+
+export class UpdateCustomerDto extends PartialType(CreateCustomerDto) {}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,0 +1,20 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/main.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: Bootstraps the NestJS application and initializes database
+//  connection.
+// 
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  await app.listen(process.env.PORT || 3001);
+}
+
+bootstrap();

--- a/api/src/ormconfig.ts
+++ b/api/src/ormconfig.ts
@@ -1,0 +1,28 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: src/ormconfig.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: TypeORM configuration loaded from environment variables.
+// 
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { Customer } from './customers/customer.entity';
+
+envLoad();
+
+const options: DataSourceOptions = {
+  type: 'postgres',
+  url: process.env.DATABASE_URL,
+  entities: [Customer],
+  migrations: ['dist/migrations/*.js'],
+};
+
+export const AppDataSource = new DataSource(options);
+
+function envLoad() {
+  if (!process.env.DATABASE_URL) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('dotenv').config({ path: '../db/.env.example' });
+  }
+}

--- a/api/test/customers.e2e-spec.ts
+++ b/api/test/customers.e2e-spec.ts
@@ -1,0 +1,50 @@
+//  App: Initial Full-Stack Application
+//  Package: api
+//  File: test/customers.e2e-spec.ts
+//  Version: 0.0.3
+//  Author: Bobwares
+//  Date: 2025-06-10T00:00:00Z
+//  Description: End-to-end tests for customer CRUD endpoints.
+// 
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('CustomerController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/customers (POST, GET)', async () => {
+    const createRes = await request(app.getHttpServer())
+      .post('/customers')
+      .send({
+        fullName: { firstName: 'Alice', lastName: 'Smith' },
+        emails: ['alice@example.com'],
+        privacySettings: { marketingEmailsEnabled: true, twoFactorEnabled: false },
+      })
+      .expect(201);
+
+    const id = createRes.body.id;
+    const listRes = await request(app.getHttpServer())
+      .get('/customers')
+      .expect(200);
+    expect(listRes.body.length).toBeGreaterThan(0);
+
+    await request(app.getHttpServer())
+      .delete(`/customers/${id}`)
+      .expect(200);
+  });
+});

--- a/db/migrations/20250612000000_create_customers.sql
+++ b/db/migrations/20250612000000_create_customers.sql
@@ -1,0 +1,18 @@
+-- App: Client Profile Module
+-- Package: db
+-- File: 20250612000000_create_customers.sql
+-- Version: 0.0.3
+-- Author: Bobwares
+-- Date: 2025-06-10T00:00:00Z
+-- Description: Create customers table for new customer domain.
+
+CREATE TABLE IF NOT EXISTS customers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    first_name TEXT NOT NULL,
+    middle_name TEXT,
+    last_name TEXT NOT NULL,
+    emails TEXT[] NOT NULL,
+    phone_numbers JSONB,
+    address JSONB,
+    privacy_settings JSONB NOT NULL
+);

--- a/schemas/customer_domain.json
+++ b/schemas/customer_domain.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CustomerProfile",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the customer profile"
+    },
+    "fullName": {
+      "$ref": "#/definitions/FullName"
+    },
+    "emails": {
+      "type": "array",
+      "description": "List of the customer’s email addresses",
+      "items": {
+        "type": "string",
+        "format": "email"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "phoneNumbers": {
+      "type": "array",
+      "description": "List of the customer’s phone numbers",
+      "items": {
+        "$ref": "#/definitions/PhoneNumber"
+      },
+      "minItems": 1
+    },
+    "address": {
+      "$ref": "#/definitions/PostalAddress"
+    },
+    "privacySettings": {
+      "$ref": "#/definitions/PrivacySettings"
+    }
+  },
+  "required": [
+    "id",
+    "fullName",
+    "emails",
+    "privacySettings"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "FullName": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Customer’s given name"
+        },
+        "middleName": {
+          "type": "string",
+          "description": "Customer’s middle name or initial",
+          "minLength": 1
+        },
+        "lastName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Customer’s family name"
+        }
+      },
+      "required": ["firstName", "lastName"],
+      "additionalProperties": false
+    },
+    "PhoneNumber": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of phone number",
+          "enum": ["mobile", "home", "work", "other"]
+        },
+        "number": {
+          "type": "string",
+          "pattern": "^\\+?[1-9]\\d{1,14}$",
+          "description": "Phone number in E.164 format"
+        }
+      },
+      "required": ["type", "number"],
+      "additionalProperties": false
+    },
+    "PostalAddress": {
+      "type": "object",
+      "properties": {
+        "line1": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Street address, P.O. box, company name, c/o"
+        },
+        "line2": {
+          "type": "string",
+          "description": "Apartment, suite, unit, building, floor, etc."
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "description": "City or locality"
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1,
+          "description": "State, province, or region"
+        },
+        "postalCode": {
+          "type": "string",
+          "description": "ZIP or postal code"
+        },
+        "country": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 2,
+          "description": "ISO 3166-1 alpha-2 country code"
+        }
+      },
+      "required": ["line1", "city", "state", "postalCode", "country"],
+      "additionalProperties": false
+    },
+    "PrivacySettings": {
+      "type": "object",
+      "properties": {
+        "marketingEmailsEnabled": {
+          "type": "boolean",
+          "description": "Whether the user opts in to marketing emails"
+        },
+        "twoFactorEnabled": {
+          "type": "boolean",
+          "description": "Whether two-factor authentication is enabled"
+        }
+      },
+      "required": [
+        "marketingEmailsEnabled",
+        "twoFactorEnabled"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/version.md
+++ b/version.md
@@ -1,2 +1,3 @@
 0.0.1 - Setup PostgreSQL docker environment and added customer profile schema. 2025-06-09T20:22:33Z
 0.0.2 - Normalize customer profile into relational tables. 2025-06-09T20:32:51Z work
+0.0.3 - Add customers CRUD API and PostgreSQL persistence. 2025-06-10T00:00:00Z work


### PR DESCRIPTION
# Summary
Implemented basic customer CRUD endpoints and PostgreSQL persistence.

# Details
* **What was added/changed?**
  * Added NestJS modules, controllers, services and DTOs for Customer domain.
  * Created TypeORM entity and migration for `customers` table.
  * Added unit and e2e tests plus .http examples.
  * Updated documentation with Customers API and database setup instructions.
  * Bumped project version to 0.0.3.
* **Why was it needed?**
  * To provide RESTful endpoints for managing customers and store data in PostgreSQL.
* **How was it implemented?**
  * TypeORM repository injected into CustomerService with CRUD methods.
  * Controllers and DTOs follow schema validation using class-validator.
  * Migration creates `customers` table; ORM config reads env vars.

# Related Tickets
- Task 03 – Implement Customer Domain CRUD Endpoints
- Task 04 – Persist Customer Data to PostgreSQL

# Checklist
- [ ] Unit tests pass (`npm test` / `pytest`)
- [ ] Integration tests pass
- [ ] Linter passes (`eslint` / `ruff`)
- [ ] Documentation updated (`README.md`, API docs)

# Screenshots / Demo (if UI)
<!-- Drop short text description or links to images/videos -->

# Breaking Changes
<!-- List any backward-incompatible changes, or “None” -->

------
https://chatgpt.com/codex/tasks/task_e_68478d5c5af0832db1afd46012c3d0bd