### PR TITLE
test: extend customer e2e examples

### DIFF
--- a/api/e2e/customers.http
+++ b/api/e2e/customers.http
@@ -10,3 +10,19 @@ Content-Type: application/json
 
 ### List customers
 GET http://localhost:3001/customers
+
+### Retrieve customer
+GET http://localhost:3001/customers/1
+
+### Update customer
+PUT http://localhost:3001/customers/1
+Content-Type: application/json
+
+{
+  "fullName": {"firstName": "Alice", "lastName": "Johnson"},
+  "emails": ["alice.j@example.com"],
+  "privacySettings": {"marketingEmailsEnabled": false, "twoFactorEnabled": true}
+}
+
+### Delete customer
+DELETE http://localhost:3001/customers/1

--- a/version.md
+++ b/version.md
@@ -1,3 +1,4 @@
 0.0.1 - Setup PostgreSQL docker environment and added customer profile schema. 2025-06-09T20:22:33Z
 0.0.2 - Normalize customer profile into relational tables. 2025-06-09T20:32:51Z work
 0.0.3 - Add customers CRUD API and PostgreSQL persistence. 2025-06-10T00:00:00Z work
+0.0.4 - Extend customers.e2e HTTP with retrieval, update, and delete examples. 2025-06-10T07:51:59Z work


### PR DESCRIPTION
# Summary
Extend customers.e2e HTTP file with additional CRUD examples.

# Details
* **What was added/changed?**
  - Added GET, PUT, and DELETE examples for `/customers/:id`.
  - Updated `version.md` to 0.0.4.
* **Why was it needed?**
  - To demonstrate complete customer CRUD via HTTP tests.
* **How was it implemented?**
  - Appended sections in `api/e2e/customers.http` with example payloads and IDs.
  - Recorded changes in `version.md`.

# Related Tickets
- None

# Checklist
- [x] Unit tests pass (`npm test` / `pytest`)
- [ ] Integration tests pass
- [ ] Linter passes (`eslint` / `ruff`)
- [x] Documentation updated (`README.md`, API docs)

# Screenshots / Demo (if UI)
N/A

# Breaking Changes
None

------
https://chatgpt.com/codex/tasks/task_e_6847e163c72c832da356909f78afe6c0