### PR TITLE
docs: clarify db script layout

### DIFF
--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -41,6 +41,25 @@ Key components include:
 - scripts/schema/: Ordered DDL scripts (e.g., 01_create_customers.sql).
 - scripts/seed/: Idempotent seed scripts (e.g., 01_seed_customers.sql).
 
+Schema creation statements belong in `scripts/schema/NN_<description>.sql`.
+Data inserts belong in `scripts/seed/NN_<description>.sql`.
+Do **not** mix table creation and seed data in the same file.
+
+Example:
+
+```sql
+-- scripts/schema/01_create_customer.sql
+CREATE TABLE IF NOT EXISTS customer (
+    customer_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+-- scripts/seed/01_seed_customer.sql
+INSERT INTO customer (name)
+VALUES ('Alice'), ('Bob')
+ON CONFLICT DO NOTHING;
+```
+
 
 **Metadata Headers**
 


### PR DESCRIPTION
# Summary
Adds guidance on separating schema and seed SQL files.

# Details
* **What was added/changed?**
  * Updated `db/AGENTS.md` with instructions that schema creation belongs in `scripts/schema/NN_<description>.sql` and data inserts in `scripts/seed/NN_<description>.sql`.
  * Included a small example showing the separation.
* **Why was it needed?**
  * Provides clearer guidelines for organizing database scripts and prevents mixing schema and seed data.
* **How was it implemented?**
  * Inserted new bullet points and a code snippet under the Directory Layout section.

# Related Tickets
- None

# Checklist
- [ ] Unit tests pass (`npm test` / `pytest`)
- [ ] Integration tests pass
- [ ] Linter passes (`eslint` / `ruff`)
- [ ] Documentation updated (`README.md`, API docs)

# Screenshots / Demo (if UI)
N/A

# Breaking Changes
None

------
https://chatgpt.com/codex/tasks/task_e_6848a5894ba4832d9e9151fa96e9c156