### PR TITLE
fix: add Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ A basic REST API is exposed under `/api`:
 * **PUT** `/customers/:id` – Update a customer
 * **DELETE** `/customers/:id` – Delete a customer
 
-If Swagger is enabled, visit `http://localhost:3001/api` to explore the API documentation.
+If Swagger is enabled, visit `http://localhost:3001/docs` to explore the API documentation.
 
 ---
 

--- a/api/README.md
+++ b/api/README.md
@@ -70,6 +70,10 @@ npm run test:coverage
 
 Test files follow the naming conventions `<module>.spec.ts` or `<module>.test.ts` and mirror the `src/` structure.
 
+## API Documentation
+
+During development, Swagger documentation is available at `http://localhost:3001/docs` when the server is running.
+
 ## Database Migrations
 
 If using TypeORM:

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,20 +1,32 @@
-/**
- * @application Job Search Backend
- * @source src/main.ts
- * @author
- * @version 1.0
- * @description Entry point of the Job Search Backend application. Sets up the NestJS server, configures CORS, and starts listening on the specified port.
- * @updated 2025-01-27
- */
+// App: Full-Stack Application
+// Package: api
+// File: src/main.ts
+// Version: 0.1.0
+// Author: Bobwares CodeBot
+// Date: 2025-06-11
+// Description: Application entrypoint configuring global pipes and Swagger docs.
+//
 
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('Job Search API')
+      .setDescription('API documentation')
+      .setVersion('1.0')
+      .build();
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('docs', app, document);
+  }
+
   await app.listen(process.env.PORT || 3001);
 }
 
-bootstrap();
+void bootstrap();

--- a/version.md
+++ b/version.md
@@ -12,3 +12,7 @@
 ### 0.0.3 - 2025-06-11T05:37:00Z (task-03-create-customer-crud-endpoints)
 - fix ESLint config and tests
 - add missing sqlite3 dependency for e2e tests
+
+### 0.0.4 - 2025-06-11T11:30:00Z (fix-swagger-link)
+- enable Swagger docs at /docs
+- update documentation


### PR DESCRIPTION
# Summary
Enable Swagger UI in the NestJS backend and update docs accordingly.

# Codex Task
[fix the swagger link is not working](https://chatgpt.com/codex/tasks/) <!-- TODO specify task id if available -->

# Details
* **What was added/changed?**
  * Added SwaggerModule setup in `api/src/main.ts` guarded for non-production environments.
  * Updated main README and API README to reference `/docs` endpoint.
  * Documented the change in `version.md`.
* **Why was it needed?**
  * Swagger link in the documentation was broken because the backend lacked configuration.
* **How was it implemented?**
  * Inserted Swagger configuration into NestJS bootstrap function.
  * Added metadata header for consistency.

# Related Tickets
- None

# Checklist
- [x] Unit tests pass (`npm test` / `pytest`)
- [ ] Integration tests pass
- [ ] Linter passes (`eslint` / `ruff`)
- [ ] Documentation updated

# Screenshots / Demo (if UI)
<!-- None -->

# Breaking Changes
None


------
https://chatgpt.com/codex/tasks/task_e_6849aa957250832d98f7b390d1e7b4eb