### PR TITLE
fix: remove unused parameter from openapi handler

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,9 +1,9 @@
 // App: Full-Stack Application
 // Package: api
 // File: src/main.ts
-// Version: 0.0.11
+// Version: 0.0.14
 // Author: Bobwares CodeBot
-// Date: 2025-06-12T07:40:00Z
+// Date: 2025-06-12T15:33:47Z
 // Description: Entry point for the NestJS backend application with Swagger documentation.
 
 import { NestFactory } from "@nestjs/core";
@@ -63,7 +63,7 @@ async function bootstrap() {
     );
   }
   SwaggerModule.setup("docs", app, document);
-  app.getHttpAdapter().get("/openapi.json", (req, res) => res.json(document));
+  app.getHttpAdapter().get("/openapi.json", (_req, res) => res.json(document));
   await app.listen(3001);
 }
 

--- a/codex-logs/2025-06-12T15-34-38Z/README.md
+++ b/codex-logs/2025-06-12T15-34-38Z/README.md
@@ -1,0 +1,1 @@
+Codex log placeholder

--- a/version.md
+++ b/version.md
@@ -109,3 +109,11 @@ Task 09 – End-to-End Tests with Supertest
 #### Changes
 - Expanded e2e suite to cover create, update, delete and error paths
 - Documented how `npm run test:e2e` uses SQLite when `APP_ENV=codex`
+
+### 0.0.14 – 2025-06-12T15:33:47Z (fix/swagger-ts-compile)
+
+#### Task
+Fix compile error due to unused req parameter
+
+#### Changes
+- Removed unused `req` parameter in Swagger OpenAPI endpoint


### PR DESCRIPTION
# Summary
Remove unused `req` parameter in Swagger OpenAPI route to satisfy TypeScript `noUnusedParameters`.

# Codex Task
[nest start](https://chatgpt.com/codex/tasks/nest%20start)

# Details
* **What was added/changed?**
  * Updated `api/src/main.ts` to use `_req` in `/openapi.json` handler.
  * Bumped metadata version and added version history.
  * Archived Codex log placeholder.
* **Why was it needed?**
  * `tsc` failed because the parameter was unused when compiling with `noUnusedParameters`.
* **How was it implemented?**
  * Renamed parameter and updated docs.

# Related Tickets
- None

# Checklist
- [x] Unit tests pass (`npm test` / `pytest`)
- [x] Integration tests pass
- [x] Linter passes (`eslint` / `ruff`)
- [x] Documentation updated

# Screenshots / Demo (if UI)
- N/A

# Breaking Changes
- None

------
https://chatgpt.com/codex/tasks/task_e_684af28bfbbc832dae762ee065e4438f