### PR TITLE
feat: add customer domain migration and seed

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -68,8 +68,32 @@ docker exec -it fullstack_baseline_db \
 
 ```
 docker compose down  
-docker compose build --no-cache db  
-docker compose up -d  
+docker compose build --no-cache db
+docker compose up -d
+```
+
+### Domain Migration
+
+To apply the customer domain migration locally:
+
+```bash
+docker compose exec db \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -f /docker-entrypoint-initdb.d/migrations/01_customer_domain.sql
+```
+
+After running the migration, seed data with:
+
+```bash
+docker compose exec db \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -f /docker-entrypoint-initdb.d/test/01_customer_domain_test_data.sql
+```
+
+Verify at least ten customers exist:
+
+```sql
+SELECT COUNT(*) FROM customer_profile.customer;
 ```
 
 ## 5. Schema Objects (snapshot)

--- a/db/entity-specs/customer_profile-entities.json
+++ b/db/entity-specs/customer_profile-entities.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "<repo-root>/entity-specs/customer_profile-entities.json",
+  "title": "customer_profile Domain Entities",
+  "type": "object",
+  "x-db": { "schema": "customer_profile" },
+  "definitions": {
+    "PostalAddress": {
+      "type": "object",
+      "properties": {
+        "address_id": { "type": "integer" },
+        "line1":      { "type": "string", "maxLength": 255 },
+        "line2":      { "type": "string", "maxLength": 255 },
+        "city":       { "type": "string", "maxLength": 100 },
+        "state":      { "type": "string", "maxLength": 50 },
+        "postal_code":{ "type": "string", "maxLength": 20 },
+        "country":    { "type": "string", "minLength": 2, "maxLength": 2 }
+      },
+      "required": [ "address_id", "line1", "city", "state", "country" ],
+      "x-db": {
+        "primaryKey": [ "address_id" ]
+      }
+    },
+    "PrivacySettings": {
+      "type": "object",
+      "properties": {
+        "privacy_settings_id":     { "type": "integer" },
+        "marketing_emails_enabled":{ "type": "boolean" },
+        "two_factor_enabled":      { "type": "boolean" }
+      },
+      "required": [
+        "privacy_settings_id",
+        "marketing_emails_enabled",
+        "two_factor_enabled"
+      ],
+      "x-db": {
+        "primaryKey": [ "privacy_settings_id" ]
+      }
+    },
+    "Customer": {
+      "type": "object",
+      "properties": {
+        "customer_id":         { "type": "string", "format": "uuid" },
+        "first_name":          { "type": "string", "maxLength": 255 },
+        "middle_name":         { "type": "string", "maxLength": 255 },
+        "last_name":           { "type": "string", "maxLength": 255 },
+        "address_id":          { "type": "integer" },
+        "privacy_settings_id": { "type": "integer" }
+      },
+      "required": [ "customer_id", "first_name", "last_name" ],
+      "x-db": {
+        "primaryKey": [ "customer_id" ],
+        "foreignKey": [
+          { "column": "address_id",          "ref": "PostalAddress.address_id" },
+          { "column": "privacy_settings_id", "ref": "PrivacySettings.privacy_settings_id" }
+        ],
+        "indexes": [
+          [ "address_id" ],
+          [ "privacy_settings_id" ]
+        ]
+      }
+    },
+    "CustomerEmail": {
+      "type": "object",
+      "properties": {
+        "email_id":    { "type": "integer" },
+        "customer_id": { "type": "string", "format": "uuid" },
+        "email":       { "type": "string", "maxLength": 255 }
+      },
+      "required": [ "email_id", "customer_id", "email" ],
+      "x-db": {
+        "primaryKey": [ "email_id" ],
+        "foreignKey": { "column": "customer_id", "ref": "Customer.customer_id" },
+        "unique":     [ [ "customer_id", "email" ] ],
+        "indexes":    [ [ "customer_id" ] ]
+      }
+    },
+    "CustomerPhoneNumber": {
+      "type": "object",
+      "properties": {
+        "phone_id":    { "type": "integer" },
+        "customer_id": { "type": "string", "format": "uuid" },
+        "type":        { "type": "string", "maxLength": 20 },
+        "number":      { "type": "string", "maxLength": 15 }
+      },
+      "required": [ "phone_id", "customer_id", "type", "number" ],
+      "x-db": {
+        "primaryKey": [ "phone_id" ],
+        "foreignKey": { "column": "customer_id", "ref": "Customer.customer_id" },
+        "unique":     [ [ "customer_id", "number" ] ],
+        "indexes":    [ [ "customer_id" ] ]
+      }
+    }
+  }
+}

--- a/db/migrations/01_customer_domain.sql
+++ b/db/migrations/01_customer_domain.sql
@@ -1,0 +1,53 @@
+-- App: Full-Stack Application
+-- Package: db
+-- File: 01_customer_domain.sql
+-- Version: 0.1.0
+-- Author: AI Agent
+-- Date: 2025-06-12
+-- Description: Creates the customer_profile schema and normalized tables.
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS customer_profile;
+SET search_path TO customer_profile, public;
+/* ---------- Reference tables ---------- */
+CREATE TABLE IF NOT EXISTS postal_address (
+    address_id  SERIAL PRIMARY KEY,
+    line1       VARCHAR(255) NOT NULL,
+    line2       VARCHAR(255),
+    city        VARCHAR(100) NOT NULL,
+    state       VARCHAR(50)  NOT NULL,
+    postal_code VARCHAR(20),
+    country     CHAR(2)      NOT NULL
+);
+CREATE TABLE IF NOT EXISTS privacy_settings (
+    privacy_settings_id      SERIAL PRIMARY KEY,
+    marketing_emails_enabled BOOLEAN NOT NULL,
+    two_factor_enabled       BOOLEAN NOT NULL
+);
+/* ---------- Root entity ---------- */
+CREATE TABLE IF NOT EXISTS customer (
+    customer_id         UUID PRIMARY KEY,
+    first_name          VARCHAR(255) NOT NULL,
+    middle_name         VARCHAR(255),
+    last_name           VARCHAR(255) NOT NULL,
+    address_id          INT REFERENCES postal_address(address_id),
+    privacy_settings_id INT REFERENCES privacy_settings(privacy_settings_id)
+);
+CREATE INDEX IF NOT EXISTS idx_customer_address_id ON customer (address_id);
+CREATE INDEX IF NOT EXISTS idx_customer_privacy_settings_id ON customer (privacy_settings_id);
+/* ---------- One-to-many collections ---------- */
+CREATE TABLE IF NOT EXISTS customer_email (
+    email_id    SERIAL PRIMARY KEY,
+    customer_id UUID NOT NULL REFERENCES customer(customer_id) ON DELETE CASCADE,
+    email       VARCHAR(255) NOT NULL,
+    UNIQUE (customer_id, email)
+);
+CREATE INDEX IF NOT EXISTS idx_customer_email_customer_id ON customer_email (customer_id);
+CREATE TABLE IF NOT EXISTS customer_phone_number (
+    phone_id    SERIAL PRIMARY KEY,
+    customer_id UUID NOT NULL REFERENCES customer(customer_id) ON DELETE CASCADE,
+    type        VARCHAR(20) NOT NULL,
+    number      VARCHAR(15) NOT NULL,
+    UNIQUE (customer_id, number)
+);
+CREATE INDEX IF NOT EXISTS idx_customer_phone_customer_id ON customer_phone_number (customer_id);
+COMMIT;

--- a/db/test/01_customer_domain_test_data.sql
+++ b/db/test/01_customer_domain_test_data.sql
@@ -1,0 +1,70 @@
+-- App: Full-Stack Application
+-- Package: db
+-- File: 01_customer_domain_test_data.sql
+-- Version: 0.1.0
+-- Author: AI Agent
+-- Date: 2025-06-12T00:00:00Z
+-- Description: Inserts sample customer domain data for testing purposes.
+BEGIN;
+INSERT INTO postal_address (address_id, line1, line2, city, state, postal_code, country) VALUES
+    (1, '100 Market St', NULL, 'Springfield', 'IL', '62701', 'US'),
+    (2, '200 Oak Ave', 'Apt 2', 'Madison', 'WI', '53703', 'US'),
+    (3, '300 Pine Rd', NULL, 'Austin', 'TX', '73301', 'US'),
+    (4, '400 Maple Ln', NULL, 'Denver', 'CO', '80014', 'US'),
+    (5, '500 Cedar Blvd', 'Suite 5', 'Phoenix', 'AZ', '85001', 'US'),
+    (6, '600 Birch Way', NULL, 'Portland', 'OR', '97035', 'US'),
+    (7, '700 Walnut St', NULL, 'Boston', 'MA', '02108', 'US'),
+    (8, '800 Chestnut Dr', NULL, 'Seattle', 'WA', '98101', 'US'),
+    (9, '900 Elm Cir', NULL, 'Atlanta', 'GA', '30303', 'US'),
+    (10, '1000 Ash Pl', NULL, 'Miami', 'FL', '33101', 'US')
+ON CONFLICT DO NOTHING;
+INSERT INTO privacy_settings (privacy_settings_id, marketing_emails_enabled, two_factor_enabled) VALUES
+    (1, TRUE, FALSE),
+    (2, FALSE, TRUE),
+    (3, TRUE, TRUE),
+    (4, FALSE, FALSE),
+    (5, TRUE, FALSE),
+    (6, FALSE, TRUE),
+    (7, TRUE, TRUE),
+    (8, FALSE, FALSE),
+    (9, TRUE, FALSE),
+    (10, FALSE, TRUE)
+ON CONFLICT DO NOTHING;
+INSERT INTO customer (customer_id, first_name, middle_name, last_name, address_id, privacy_settings_id) VALUES
+    ('11111111-1111-1111-1111-111111111111', 'Alice', NULL, 'Smith', 1, 1),
+    ('22222222-2222-2222-2222-222222222222', 'Bob', 'J', 'Jones', 2, 2),
+    ('33333333-3333-3333-3333-333333333333', 'Charlie', NULL, 'Brown', 3, 3),
+    ('44444444-4444-4444-4444-444444444444', 'David', 'K', 'Miller', 4, 4),
+    ('55555555-5555-5555-5555-555555555555', 'Emma', NULL, 'Davis', 5, 5),
+    ('66666666-6666-6666-6666-666666666666', 'Frank', NULL, 'Wilson', 6, 6),
+    ('77777777-7777-7777-7777-777777777777', 'Grace', 'L', 'Taylor', 7, 7),
+    ('88888888-8888-8888-8888-888888888888', 'Hugo', NULL, 'Anderson', 8, 8),
+    ('99999999-9999-9999-9999-999999999999', 'Isabel', NULL, 'Thomas', 9, 9),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Jack', 'M', 'Jackson', 10, 10)
+ON CONFLICT DO NOTHING;
+INSERT INTO customer_email (customer_id, email) VALUES
+    ('11111111-1111-1111-1111-111111111111', 'alice@example.com'),
+    ('22222222-2222-2222-2222-222222222222', 'bob@example.com'),
+    ('33333333-3333-3333-3333-333333333333', 'charlie@example.com'),
+    ('44444444-4444-4444-4444-444444444444', 'david@example.com'),
+    ('55555555-5555-5555-5555-555555555555', 'emma@example.com'),
+    ('66666666-6666-6666-6666-666666666666', 'frank@example.com'),
+    ('77777777-7777-7777-7777-777777777777', 'grace@example.com'),
+    ('88888888-8888-8888-8888-888888888888', 'hugo@example.com'),
+    ('99999999-9999-9999-9999-999999999999', 'isabel@example.com'),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'jack@example.com')
+ON CONFLICT DO NOTHING;
+INSERT INTO customer_phone_number (customer_id, type, number) VALUES
+    ('11111111-1111-1111-1111-111111111111', 'mobile', '+15555550101'),
+    ('22222222-2222-2222-2222-222222222222', 'mobile', '+15555550102'),
+    ('33333333-3333-3333-3333-333333333333', 'mobile', '+15555550103'),
+    ('44444444-4444-4444-4444-444444444444', 'mobile', '+15555550104'),
+    ('55555555-5555-5555-5555-555555555555', 'mobile', '+15555550105'),
+    ('66666666-6666-6666-6666-666666666666', 'mobile', '+15555550106'),
+    ('77777777-7777-7777-7777-777777777777', 'mobile', '+15555550107'),
+    ('88888888-8888-8888-8888-888888888888', 'mobile', '+15555550108'),
+    ('99999999-9999-9999-9999-999999999999', 'mobile', '+15555550109'),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'mobile', '+15555550110')
+ON CONFLICT DO NOTHING;
+-- Smoke test: SELECT COUNT(*) FROM customer;
+COMMIT;

--- a/version.md
+++ b/version.md
@@ -1,1 +1,12 @@
+# Version History
 
+### 0.1.0 – 2025-06-12 UTC (work)
+
+#### Task
+Execute DB tasks 01-03
+
+#### Changes
+- Generate customer domain migration from JSON schema
+- Produce entity spec JSON from SQL
+- Create test data script
+- Document migration steps in db/README.md


### PR DESCRIPTION
## Summary
- generate migration from customer JSON schema
- convert SQL schema to JSON entity specs
- create customer domain sample data
- document how to run new migration and seed

## Testing
- `npx -y ajv-cli compile -s db/entity-specs/customer_profile-entities.json` *(fails: no schema with key or ref)*

------
https://chatgpt.com/codex/tasks/task_e_684b4ba589c8832dbadfb1626155536b